### PR TITLE
Fix TS typing for `"moduleResolution": "Bundler"`

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
   ],
   "exports": {
     ".": {
-      "import": "./dist/vue-draggable-plus.js",
-      "require": "./dist/vue-draggable-plus.cjs",
+      "import": { "types": "./dist/index.d.ts", "default": "./dist/vue-draggable-plus.js" },
+      "require": { "types": "./dist/index.d.ts", "default": "./dist/vue-draggable-plus.cjs" },
       "default": "./dist/vue-draggable-plus.umd.cjs"
     }
   },


### PR DESCRIPTION
Currently trying to import anything from `vue-draggable-plus` in TS file with tsconfig `{ "compilerOptions": { "module": "ESNext", "moduleResolution": "Bundler", "strict": true } }`  results in TS error.
This PR fixes provided typings by correctly setting "types" field in `package.json`.

For more info see this issue: https://github.com/microsoft/TypeScript/issues/52363
Also there is this nifty tool to check if types are correct: https://arethetypeswrong.github.io/?p=vue-draggable-plus

This is not a perfect fix, as `"module": "Node16"` still won't work, but fixing that would require reconsidering usage of UMD builds.