### PR TITLE
Fix: `clone` not in component props

### DIFF
--- a/src/component.ts
+++ b/src/component.ts
@@ -32,6 +32,7 @@ const emits = [
 ] as const
 
 const props = [
+  'clone',
   'animation',
   'ghostClass',
   'group',
@@ -93,7 +94,7 @@ export const VueDraggable = defineComponent<IProps>({
     }, {} as any)
 
     const options = computed(() => {
-      // eslint-disable-next-line 
+      // eslint-disable-next-line
       const { modelValue, ...rest } = toRefs(props)
       const opt = Object.entries(rest).reduce((acc, [key, value]) => {
         // @ts-ignore


### PR DESCRIPTION
`clone` not in props result in the following issue:

![image](https://github.com/Alfred-Skyblue/vue-draggable-plus/assets/96933655/954f9549-f863-492d-b930-00ece5717439)