### PR TITLE
fix: `update:model-value` not triggering on add and remove

### DIFF
--- a/src/useDraggable.ts
+++ b/src/useDraggable.ts
@@ -156,8 +156,8 @@ export function useDraggable<T>(...args: any[]): UseDraggableReturn {
    */
   function onRemove(evt: DraggableEvent) {
     const { from, item, oldIndex, oldDraggableIndex, pullMode, clone } = evt
+    insertNodeAt(from, item, oldIndex!)
     if (pullMode === 'clone') {
-      insertNodeAt(from, item, oldIndex!)
       removeNode(clone)
       return
     }

--- a/src/useDraggable.ts
+++ b/src/useDraggable.ts
@@ -142,6 +142,11 @@ export function useDraggable<T>(...args: any[]): UseDraggableReturn {
     const element = evt.item[CLONE_ELEMENT_KEY]
     if (isUndefined(element)) return
     removeNode(evt.item)
+    if (isRef<any[]>(list)) {
+      const newList = [...unref(list)]
+      list.value = insertElement(newList, evt.newDraggableIndex!, element)
+      return
+    }
     insertElement(unref(list), evt.newDraggableIndex!, element)
   }
 
@@ -154,6 +159,11 @@ export function useDraggable<T>(...args: any[]): UseDraggableReturn {
     if (pullMode === 'clone') {
       insertNodeAt(from, item, oldIndex!)
       removeNode(clone)
+      return
+    }
+    if (isRef<any[]>(list)) {
+      const newList = [...unref(list)]
+      list.value = removeElement(newList, oldDraggableIndex!)
       return
     }
     removeElement(unref(list), oldDraggableIndex!)

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,11 +1,12 @@
+import { warn } from './log'
+
 /**
  * Moves an element in an array from one position to another.
  * @param {T[]} array
  * @param {number} from
  * @param {number} to
+ * @returns {T[]}
  */
-import { warn } from './log'
-
 export function moveArrayElement<T>(array: T[], from: number, to: number): T[] {
   if (to >= 0 && to < array.length) {
     array.splice(to, 0, array.splice(from, 1)[0])
@@ -43,7 +44,8 @@ export function objectMap(object: Record<any, any>) {
  * @returns {T[]}
  */
 export function removeElement<T>(array: T[], index: number) {
-  if (Array.isArray(array)) return array.splice(index, 1)
+  if (Array.isArray(array)) array.splice(index, 1)
+  return array
 }
 
 /**
@@ -51,9 +53,11 @@ export function removeElement<T>(array: T[], index: number) {
  * @param {T[]} array
  * @param {number} index
  * @param element
+ * @returns {T[]}
  */
 export function insertElement<T>(array: T[], index: number, element: any) {
-  if (Array.isArray(array)) return array.splice(index, 0, element)
+  if (Array.isArray(array)) array.splice(index, 0, element)
+  return array
 }
 
 /**


### PR DESCRIPTION
When `onAdd` and `onRemoved` is triggered the list got updated in-place.
This leads to an undesired prop manipulation in the `VueDraggable` component, because the writable computed that manages the `update:model-value` emit isn't triggered trough in-place updates of arrays.

The `onUpdate` method already had a fix to sidestep this behavior. So, I applied it to `onAdd` and `onRemoved` also.

While testing I noticed that the `onRemove` method is reverting the SortableJS DOM manipulation only when clone mode is active. SortableJS removes the DOM element in any case, so `insertNodeAt` needs to be called outside of the if-statement.

### In conclusion:
These changes streamline the behavior of the composable with writable computeds and fixes missing `update:model-value` emits.
By extension it's now possible to use the component with `:model-value` when automatic updates of the list are not desired.