### PR TITLE
feat: extended SortalbeJS events with data attribute

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,14 @@
 import type { Ref } from 'vue'
-export { type Options, type SortableEvent } from 'sortablejs'
+import type { SortableEvent, MoveEvent } from 'sortablejs'
+export { type Options, type SortableEvent, type MoveEvent } from 'sortablejs'
+
+export interface SortableDataEvent extends SortableEvent {
+  itemData?: any
+}
+
+export interface MoveDataEvent extends MoveEvent {
+  draggedData?: any
+}
 
 export type RefOrValue<T> = T | Ref<T>
 export type RefOrElement<T = HTMLElement> =


### PR DESCRIPTION
Maybe this PR ist out of scope for `vue-draggable-plus` but I would like to see this or a similar feature in this library.

It's a hassle to implement custom logic on Sortable Events, because SortableJS only works on the DOM level.
This Library works on a data level and delegates the DOM manipulation to Vue.js. It would be nice to get more data access in the emitted events on the component and in the callbacks in the composable.

[vue.draggable.next](https://github.com/SortableJS/vue.draggable.next) implements this using a custom `change` event with references the underlying data.

`vue-draggable-plus` already uses a workaround to connect data to SortableEvents. Data is saved to the `HTMLElement` which is dragged. This is currently only used to insert data from draggable list to another.

This PR uses this method to expose the data to every SortableJs event.
To make this work for all events the data needs to be attached in the `onChoose` event, because it's triggered before `onStart`.

During `mergeOptions` the passed options are extended with an data attribute that is read from the already extended `HTMLElement`.

With these changes it is much easier to implement side effects on SortableEvents.
For example showing a push notification when an element is added to a list would be possible with:
```ts
@add="(e) => showNotification(e.itemData.name + ' was added')"
```

I`m open to suggestions on how this feature could be implemented in an more elegant way. This is the best I could come up with.