### PR TITLE
fix: optional parameter handling in useDraggable function

### DIFF
--- a/src/useDraggable.ts
+++ b/src/useDraggable.ts
@@ -114,7 +114,7 @@ export function useDraggable<T>(...args: any[]): UseDraggableReturn {
   const el = args[0]
   let [, list, options] = args
 
-  if (!Array.isArray(unref(list))) {
+  if (args.length === 2 && !Array.isArray(unref(list))) {
     options = list
     list = null
   }
@@ -217,7 +217,7 @@ export function useDraggable<T>(...args: any[]): UseDraggableReturn {
     // eslint-disable-next-line
     const { immediate, clone, ...restOptions } = unref(options) ?? {}
     return mergeOptionsEvents(
-      list === null ? {} : presetOptions,
+      list == null ? {} : presetOptions,
       restOptions
     ) as Options
   }


### PR DESCRIPTION
When called in this way, the parameters are not processed correctly. The options should be applied correctly.

`useDraggable(el, undefined, { animation: 150, handle: '.handle' })`