### PR TITLE
docs: format the spacing

### DIFF
--- a/src/__docs__/basic/index.en-US.md
+++ b/src/__docs__/basic/index.en-US.md
@@ -1,6 +1,6 @@
 ---
 map:
- path: /demo/basic
+  path: /demo/basic
 ---
 
 # Basic Usage

--- a/src/__docs__/basic/index.zh-CN.md
+++ b/src/__docs__/basic/index.zh-CN.md
@@ -1,6 +1,6 @@
 ---
 map:
- path: /demo/basic
+  path: /demo/basic
 ---
 
 # 基础使用

--- a/src/__docs__/clone/index.en-US.md
+++ b/src/__docs__/clone/index.en-US.md
@@ -1,6 +1,6 @@
 ---
 map:
- path: /demo/clone
+  path: /demo/clone
 ---
 
 # Drag Clone

--- a/src/__docs__/custom-clone/index.en-US.md
+++ b/src/__docs__/custom-clone/index.en-US.md
@@ -1,6 +1,6 @@
 ---
 map:
- path: /demo/custom-clone
+  path: /demo/custom-clone
 ---
 
 # Custom Clone

--- a/src/__docs__/faq/index.en-US.md
+++ b/src/__docs__/faq/index.en-US.md
@@ -1,6 +1,6 @@
 ---
 map:
- path: /faq/
+  path: /faq/
 ---
 
 # FAQ

--- a/src/__docs__/guide/index.en-US.md
+++ b/src/__docs__/guide/index.en-US.md
@@ -1,6 +1,6 @@
 ---
 map:
- path: /guide/
+  path: /guide/
 ---
 
 # vue-draggable-plus

--- a/src/__docs__/guide/index.zh-CN.md
+++ b/src/__docs__/guide/index.zh-CN.md
@@ -1,6 +1,6 @@
 ---
 map:
- path: /guide/
+  path: /guide/
 ---
 # vue-draggable-plus
 

--- a/src/__docs__/index.en-US.md
+++ b/src/__docs__/index.en-US.md
@@ -1,6 +1,6 @@
 ---
 map:
- path: /
+  path: /
 ---
 ---
 layout: home

--- a/src/__docs__/index.zh-CN.md
+++ b/src/__docs__/index.zh-CN.md
@@ -1,4 +1,8 @@
 ---
+map:
+  path: /
+---
+---
 layout: home
 
 title: VueDraggablePlus

--- a/src/__docs__/table-column/index.en-US.md
+++ b/src/__docs__/table-column/index.en-US.md
@@ -1,6 +1,6 @@
 ---
 map:
- path: /demo/table-column
+  path: /demo/table-column
 ---
 # Table Column
 

--- a/src/__docs__/target-container/index.en-US.md
+++ b/src/__docs__/target-container/index.en-US.md
@@ -1,6 +1,6 @@
 ---
 map:
- path: /demo/target-container
+  path: /demo/target-container
 ---
 
 # Specify the target container

--- a/src/__docs__/tow-list/index.en-US.md
+++ b/src/__docs__/tow-list/index.en-US.md
@@ -1,6 +1,6 @@
 ---
 map:
- path: /demo/tow-list
+  path: /demo/tow-list
 ---
 # Double list drag and drop sorting
 

--- a/src/__docs__/transition/index.en-US.md
+++ b/src/__docs__/transition/index.en-US.md
@@ -1,6 +1,6 @@
 ---
 map:
- path: /demo/transition
+  path: /demo/transition
 ---
 # Transition
 

--- a/src/__docs__/transitions/index.en-US.md
+++ b/src/__docs__/transitions/index.en-US.md
@@ -1,6 +1,6 @@
 ---
 map:
- path: /demo/transitions
+  path: /demo/transitions
 ---
 # Mixin Animation
 


### PR DESCRIPTION
部分md文档 path 前是单空格，统一格式