### PR TITLE
Add "vue" keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "sideEffects": false,
   "license": "MIT",
   "keywords": [
+    "vue",
     "vue2.x",
     "vue3.x",
     "Sortable",


### PR DESCRIPTION
Hi there,
couple of days ago I started research for a drag & drop component which can easily be integrated in our Vue application.

I did not stumble over this *perfect* solution easily because I tried to find successors of [`vue-draggable-next`](https://www.npmjs.com/package/vue3-draggable-next) by permutation of related keywords.

To improve visibility I suggest you add the "vue" keyword. All the older, outdated components use this one as keyword.

Thanks for the great job!