### PR TITLE
add onstart callback fetaure

### DIFF
--- a/src/useDraggable.ts
+++ b/src/useDraggable.ts
@@ -92,7 +92,7 @@ export interface UseDraggableReturn extends Pick<Sortable, SortableMethod> {
 }
 
 export interface UseDraggableOptions<T> extends Options {
-  clone?: (element: T) => T
+  clone?: (element: T) => T | Promise<T> | false
   immediate?: boolean
   customUpdate?: (event: SortableEvent) => void
 }
@@ -152,9 +152,12 @@ export function useDraggable<T>(...args: any[]): UseDraggableReturn {
    * Element dragging started
    * @param {DraggableEvent} evt - DraggableEvent
    */
-  function onStart(evt: DraggableEvent) {
+  async function onStart(evt: DraggableEvent) {
     const data = unref(unref(list)?.[evt.oldIndex!])
-    const clonedData = clone(data)
+    const clonedData = await clone(data)
+    if (clonedData === false) {
+      return;
+    }
     setCurrentData(data, clonedData)
     evt.item[CLONE_ELEMENT_KEY] = clonedData
   }


### PR DESCRIPTION
In the onStart method, you may need to interrupt dragging or placing elements, or rendering and placing elements requires obtaining data from the terminal, so the following is added:
1. Allow the clone method to be an asynchronous function
2. Add the return type of clone method: Promise and false can be returned. When false is returned, it will not be updated.