### PR TITLE
fix: remove last child node when forceFallback is active

### DIFF
--- a/src/useDraggable.ts
+++ b/src/useDraggable.ts
@@ -141,6 +141,8 @@ export function useDraggable<T>(...args: any[]): UseDraggableReturn {
   const {
     immediate = true,
     clone = defaultClone,
+    forceFallback,
+    fallbackOnBody,
     customUpdate
   } = unref(options) ?? {}
 
@@ -150,7 +152,8 @@ export function useDraggable<T>(...args: any[]): UseDraggableReturn {
    */
   function onStart(evt: DraggableEvent) {
     const { from, oldIndex, item } = evt
-    currentNodes = Array.from(from.childNodes)
+    const nodes = Array.from(from.childNodes);
+    currentNodes = forceFallback && !fallbackOnBody ? nodes.toSpliced(-1) : nodes;
     const data = unref(unref(list)?.[oldIndex!])
     const clonedData = clone(data)
     setCurrentData(data, clonedData)

--- a/src/useDraggable.ts
+++ b/src/useDraggable.ts
@@ -153,7 +153,7 @@ export function useDraggable<T>(...args: any[]): UseDraggableReturn {
   function onStart(evt: DraggableEvent) {
     const { from, oldIndex, item } = evt
     const nodes = Array.from(from.childNodes);
-    currentNodes = forceFallback && !fallbackOnBody ? nodes.toSpliced(-1) : nodes;
+    currentNodes = forceFallback && !fallbackOnBody ? nodes.slice(0, -1) : nodes;
     const data = unref(unref(list)?.[oldIndex!])
     const clonedData = clone(data)
     setCurrentData(data, clonedData)


### PR DESCRIPTION
When `forceFallback` is active, childNode gets created, and when you drag and drop to the same position, [this check](https://github.com/Alfred-Skyblue/vue-draggable-plus/blob/main/src/useDraggable.ts#L224) fails because nodes are no longer the same length and it causes first two elements to shift positions in DOM.

Note: This example is in vue2

[Screencast from 2024-11-04 09-06-08.webm](https://github.com/user-attachments/assets/e32eb120-7e8c-46a6-9c16-e7bb1b9d2ad2)


