### PR TITLE
fix: resolve element flickering when dragging to empty container

### DIFF
--- a/src/useDraggable.ts
+++ b/src/useDraggable.ts
@@ -253,7 +253,8 @@ export function useDraggable<T>(...args: any[]): UseDraggableReturn {
     onStart,
     onAdd,
     onRemove,
-    onEnd
+    onEnd,
+    emptyInsertThreshold: 0
   }
 
   function getTarget(target?: HTMLElement) {


### PR DESCRIPTION
fix(draggable): resolve container flickering when dragging to empty container

This commit fixes an issue where dragged elements flicker when attempting to drag 
into an empty container that overlaps with another container. The fix is implemented 
by setting emptyInsertThreshold to 0, which ensures more precise drop target detection.

- Set emptyInsertThreshold to 0 in presetOptions
- This prevents false positive drop target detection when hovering between containers
- Improves drag and drop accuracy for overlapping containers

Closes #215 