### PR TITLE
Reexport MoveEvent from Sortablejs

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,5 @@
 import type { Ref, ShallowRef, WritableComputedRef } from 'vue'
-export { type Options, type SortableEvent } from 'sortablejs'
+export { type Options, type SortableEvent, type MoveEvent } from 'sortablejs'
 
 /**
  * @deprecated Use MaybeRef<T> instead


### PR DESCRIPTION
Just like SortableEvent MoveEvent should also be reexported.

 I rely on this to type my listeners.